### PR TITLE
Changes to the CoC

### DIFF
--- a/wiki/code-of-conduct.md
+++ b/wiki/code-of-conduct.md
@@ -9,14 +9,13 @@ tag: [sidebar]
 A primary goal of the International HPC Summer School (IHPCSS) is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible.
 As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
 
-This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+This code of conduct outlines our expectations for all those who participate in our community (students, mentors, staff, and others), as well as the consequences for unacceptable behavior.
 
 We invite all those who participate in the summer school to help us create safe and positive experiences for everyone.
 
 ## 1. Expected Behavior
 
-All IHPCSS participants are expected to comply with both local laws and the laws governing their home institutions.
-In addition, the following behaviors are expected and requested of all community members:
+he following behaviors are expected and requested of all IHPCSS participants and community members:
 
 - All participants, attendees, IHPCSS staff, and related personnel are to be treated with respect and dignity, valuing a diversity of views and opinions.
 - Be considerate and collaborative, critiquing ideas rather than individuals.
@@ -31,7 +30,7 @@ We are a community of professionals and we conduct ourselves professionally.
 ## 2. Unacceptable Behavior
 
 The following behaviors are considered harassment and are unacceptable during the summer school.
-If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate.
+If a community member engages in unacceptable behavior, they may be asked to leave the event without warning or refund, at the sole discretion of the IHPCSS organizers.
 
 - Physical or verbal abuse of any attendee, speaker, volunteer, exhibitor, IHPCSS staff member, service provider, or other meeting guest.
 - Examples of unacceptable behavior include, but are not limited to, harassment, intimidation, discrimination, inappropriate use of nudity and/or sexual images in public spaces or in presentations, or threatening or stalking any attendee, speaker, volunteer, exhibitor, IHPCSS staff member, service provider, or other meeting guest.

--- a/wiki/code-of-conduct.md
+++ b/wiki/code-of-conduct.md
@@ -15,7 +15,7 @@ We invite all those who participate in the summer school to help us create safe 
 
 ## 1. Expected Behavior
 
-he following behaviors are expected and requested of all IHPCSS participants and community members:
+The following behaviors are expected and requested of all IHPCSS participants and community members:
 
 - All participants, attendees, IHPCSS staff, and related personnel are to be treated with respect and dignity, valuing a diversity of views and opinions.
 - Be considerate and collaborative, critiquing ideas rather than individuals.


### PR DESCRIPTION
@scallag @wfilinger 

This change tries to incorporate the addendum we had to add last year:

- Agreeing to this statement does not and cannot supersede any law, nor would it constitutes a waiver of rights of any kind.
- Wherever “to comply with both local laws and the laws governing their home institutions” would lead to conflicts, the IHPCSS organizers take no position as to which one applies, as this is a legal matter.
- All actions taken by the organizers are also subject to this agreement, and to any applicable law.- 
- “Any action deemed necessary” is supposed to mean any reasonable action to ensure a safe and welcoming environment.